### PR TITLE
Add linux platform to bundle lock

### DIFF
--- a/.github/workflows/jekyll.yml
+++ b/.github/workflows/jekyll.yml
@@ -10,6 +10,9 @@ on:
 
 jobs:
   build_and_deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     permissions:
       pages: write      # to deploy to Pages
       id-token: write   # to verify the deployment originates from an appropriate source
@@ -24,14 +27,11 @@ jobs:
           ruby-version: 3.3.0
           bundler-cache: true
 
-      - name: Install dependencies
-        run: bundle install
-
       - name: Build Jekyll Site
         run: bundle exec jekyll build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-pages-artifact@v3
 
       - name: Deploy to GitHub Pages
         id: deployment

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,8 @@ GEM
       rake (>= 13)
     google-protobuf (4.26.1-x64-mingw-ucrt)
       rake (>= 13)
+    google-protobuf (4.26.1-x86_64-linux)
+      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.5)
       concurrent-ruby (~> 1.0)
@@ -70,6 +72,8 @@ GEM
       google-protobuf (>= 3.25, < 5.0)
     sass-embedded (1.77.0-x64-mingw-ucrt)
       google-protobuf (>= 3.25, < 5.0)
+    sass-embedded (1.77.0-x86_64-linux-gnu)
+      google-protobuf (>= 3.25, < 5.0)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     tzinfo (2.0.6)
@@ -83,6 +87,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   x64-mingw-ucrt
+  x86_64-linux
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)


### PR DESCRIPTION
This fixes a bad lockfile GH actions error - this comes from building on my Mac. Whoops!